### PR TITLE
Use values of config.yml for DB settings. Replace hyphen to under-bar for the default DB name.

### DIFF
--- a/conf/config.yml
+++ b/conf/config.yml
@@ -5,7 +5,7 @@ db:
   #   dbName: "go-scraper"
   #   user: "user"
   #   password: "password"
-  dbName: "go_scraper"
+  dbName: "go-scraper"
   user: "user"
   password: "password"
 baseURL: "http://localhost:3000/"

--- a/conf/config.yml
+++ b/conf/config.yml
@@ -5,7 +5,7 @@ db:
   #   dbName: "go-scraper"
   #   user: "user"
   #   password: "password"
-  dbName: "go-scraper"
+  dbName: "go_scraper"
   user: "user"
   password: "password"
 baseURL: "http://localhost:3000/"

--- a/main.go
+++ b/main.go
@@ -304,7 +304,7 @@ func configure() (Config, error) {
 	var config Config
 	viper.SetDefault("db.host", "localhost")
 	viper.SetDefault("db.port", "3306")
-	viper.SetDefault("db.dbName", "go_scraper")
+	viper.SetDefault("db.dbName", "go-scraper")
 	viper.SetDefault("db.user", "user")
 	viper.SetDefault("db.password", "password")
 	viper.SetDefault("baseURL", "http://localhost:3000/")

--- a/main.go
+++ b/main.go
@@ -53,11 +53,11 @@ func main() {
 }
 
 func gormConnect(config Config) (*gorm.DB, error) {
-	dbHost := "localhost"
-	dbPort := "3306"
-	dbName := "go-scraper-dev"
-	dbUser := "root"
-	dbPassword := "root"
+	dbHost := config.Db.Host
+	dbPort := config.Db.Port
+	dbName := config.Db.DbName
+	dbUser := config.Db.User
+	dbPassword := config.Db.Password
 
 	db, err := gorm.Open("mysql", fmt.Sprintf("%s:%s@(%s:%s)/%s?charset=utf8&parseTime=True&loc=Local", dbUser, dbPassword, dbHost, dbPort, dbName))
 	if err != nil {
@@ -304,7 +304,7 @@ func configure() (Config, error) {
 	var config Config
 	viper.SetDefault("db.host", "localhost")
 	viper.SetDefault("db.port", "3306")
-	viper.SetDefault("db.dbName", "go-scraper")
+	viper.SetDefault("db.dbName", "go_scraper")
 	viper.SetDefault("db.user", "user")
 	viper.SetDefault("db.password", "password")
 	viper.SetDefault("baseURL", "http://localhost:3000/")


### PR DESCRIPTION
対応内容
* config.ymlからDB設定を読み取れるように修正
* DB名のデフォルトをハイフンではなくアンダーバーに変更